### PR TITLE
Support für App Shortcuts (API 25)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -137,6 +137,9 @@
                     android:pathPrefix="/user"
                     android:scheme="https"/>
             </intent-filter>
+            <meta-data
+                    android:name="android.app.shortcuts"
+                    android:resource="@xml/shortcuts"/>
         </activity>
         <activity
             android:name=".ui.InboxActivity"

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="top"
+        android:enabled="true"
+        android:icon="@drawable/ic_black_action_home"
+        android:shortcutShortLabel="@string/action_feed_type_promoted"
+        android:shortcutLongLabel="@string/action_feed_type_promoted"
+        android:shortcutDisabledMessage="@string/action_feed_type_promoted">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.pr0gramm.app"
+            android:targetClass="com.pr0gramm.app.ui.MainActivity"
+            android:data="/top" />
+    </shortcut>
+    <shortcut
+        android:shortcutId="new"
+        android:enabled="true"
+        android:icon="@drawable/ic_black_action_trending"
+        android:shortcutShortLabel="@string/action_feed_type_new"
+        android:shortcutLongLabel="@string/action_feed_type_new"
+        android:shortcutDisabledMessage="@string/action_feed_type_new">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.pr0gramm.app"
+            android:targetClass="com.pr0gramm.app.ui.MainActivity"
+            android:data="/new" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
Mit API 25 wurden App Shortcuts eingeführt, siehe https://developer.android.com/guide/topics/ui/shortcuts.html. Zur Zeit können die Kategorien Neu und Top dadurch geöffnet werden. Gegebenfalls kann das noch erweitert werden oder die Reihenfolge der zu öffnenden Kategorien geändert werden.
![pr0_shortcuts](https://cloud.githubusercontent.com/assets/1213925/21280188/a5bc2628-c3e4-11e6-8b1c-8ddcab9e0419.jpg)
