### PR TITLE
"neuste" zu "neueste" Fehler im Changelog

### DIFF
--- a/app/src/main/res/raw/changelog.json
+++ b/app/src/main/res/raw/changelog.json
@@ -8,7 +8,7 @@
       },
       {
         "type": "Neu",
-        "change": "Support für Adaptive Icons auf neusten Android Versionen."
+        "change": "Support für Adaptive Icons auf neuesten Android Versionen."
       },
       {
         "type": "Fix",


### PR DESCRIPTION
https://www.duden.de/rechtschreibung/neuestens