### PR TITLE
Add double tap to control video

### DIFF
--- a/app/src/main/java/com/pr0gramm/app/ui/fragments/PostFragment.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/fragments/PostFragment.kt
@@ -916,7 +916,7 @@ class PostFragment : BaseFragment("PostFragment"), NewTagDialogFragment.OnAddNew
                 return true
             }
 
-            override fun onDoubleTap(): Boolean {
+            override fun onDoubleTap(event: MotionEvent): Boolean {
                 if (settings.doubleTapToUpvote) {
                     launch { doVoteOnDoubleTap() }
                 }

--- a/app/src/main/java/com/pr0gramm/app/ui/views/viewer/AbstractProgressMediaView.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/views/viewer/AbstractProgressMediaView.kt
@@ -54,6 +54,11 @@ abstract class AbstractProgressMediaView(config: MediaView.Config, @LayoutRes la
         updateTimeline()
     }
 
+
+    override fun onDoubleTap(event: MotionEvent): Boolean {
+        return super.onDoubleTap(event)
+    }
+
     override fun onSingleTap(event: MotionEvent): Boolean {
         if (userSeekable()) {
             if (seekCurrentlyVisible()) {

--- a/app/src/main/java/com/pr0gramm/app/ui/views/viewer/MediaView.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/views/viewer/MediaView.kt
@@ -278,7 +278,7 @@ abstract class MediaView(protected val config: MediaView.Config, @LayoutRes layo
         }
 
         override fun onDoubleTap(e: MotionEvent): Boolean {
-            return this@MediaView.onDoubleTap()
+            return this@MediaView.onDoubleTap(e)
         }
 
         override fun onSingleTapConfirmed(event: MotionEvent): Boolean {
@@ -286,8 +286,8 @@ abstract class MediaView(protected val config: MediaView.Config, @LayoutRes layo
         }
     }
 
-    protected fun onDoubleTap(): Boolean {
-        return tapListener?.onDoubleTap() ?: false
+    protected open fun onDoubleTap(event: MotionEvent): Boolean {
+        return tapListener?.onDoubleTap(event) ?: false
 
     }
 
@@ -442,7 +442,7 @@ abstract class MediaView(protected val config: MediaView.Config, @LayoutRes layo
     interface TapListener {
         fun onSingleTap(event: MotionEvent): Boolean
 
-        fun onDoubleTap(): Boolean
+        fun onDoubleTap(event: MotionEvent): Boolean
     }
 
     private class PreviewTarget(private val logger: KLogger, mediaView: MediaView) : Action1<Bitmap> {

--- a/app/src/main/java/com/pr0gramm/app/ui/views/viewer/ProxyMediaView.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/views/viewer/ProxyMediaView.kt
@@ -137,8 +137,8 @@ abstract class ProxyMediaView internal constructor(config: MediaView.Config) : M
             return tapListener?.onSingleTap(event) ?: false
         }
 
-        override fun onDoubleTap(): Boolean {
-            return tapListener?.onDoubleTap() ?: false
+        override fun onDoubleTap(event: MotionEvent): Boolean {
+            return tapListener?.onDoubleTap(event) ?: false
         }
     }
 }

--- a/app/src/main/res/layout/player_kind_video.xml
+++ b/app/src/main/res/layout/player_kind_video.xml
@@ -12,4 +12,5 @@
         android:layout_centerHorizontal="true"/>
 
     <include layout="@layout/player_progress"/>
+    <include layout="@layout/player_video_skipper"/>
 </merge>

--- a/app/src/main/res/layout/player_video_skipper.xml
+++ b/app/src/main/res/layout/player_video_skipper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/rewind"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:paddingLeft="25dp"
+        android:src="@android:drawable/ic_media_rew"
+        android:visibility="invisible" />
+
+    <Space
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+
+    <ImageView
+        android:id="@+id/fast_forward"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:paddingRight="25dp"
+        android:src="@android:drawable/ic_media_ff"
+        android:visibility="invisible" />
+</LinearLayout>


### PR DESCRIPTION
Hier ein Vorschlag zur Verbesserung des Videoplayers. YouTube (App und mobile Web) bietet die Möglichkeit in Videos ein paar Sekunden vor und zurück zu spulen, wenn man doppelt in eine Bildschirmhälfte tippt. Das habe ich hier auch mal eingebaut. Andere Funktionen wie double tap to vote werden davon nicht beeinträchtigt.

Demo hier: https://imgur.com/a/98f1fx6

Wenn du das Feature gut findest wäre noch die Frage offen, wie lange geskipt werden soll (derzeit abhängig von der Videolänge) und ob man die Länge in den Einstellungen festlegen soll.