### PR TITLE
#239: fix inverted colors by disable force dark mode for images

### DIFF
--- a/app/src/main/java/com/pr0gramm/app/ui/views/AspectImageView.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/views/AspectImageView.kt
@@ -40,6 +40,13 @@ class AspectImageView @JvmOverloads constructor(context: Context, attrs: Attribu
             }
         }
 
+    /**
+     * Prevent s/w images from being color inverted
+     */
+    override fun isForceDarkAllowed(): Boolean {
+        return false
+    }
+
     init {
         // apply attributes
         aspect = context.theme.obtainStyledAttributes(attrs, R.styleable.AspectView, 0, 0).use {


### PR DESCRIPTION
#239 disable forced dark mode for `AspectImageView` to prevent images from being color inverted