### PR TITLE
Feature: "Nutzer kann keine PNs empfangen"

### DIFF
--- a/app/src/main/java/com/pr0gramm/app/ui/fragments/conversation/ConversationFragment.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/fragments/conversation/ConversationFragment.kt
@@ -125,6 +125,15 @@ class ConversationFragment : BaseFragment("ConversationFragment", R.layout.fragm
         views.actionSend.setOnClickListener {
             sendInboxMessage()
         }
+
+        model.partner.observe(viewLifecycleOwner) {
+            if(!it.canReceiveMessages) {
+                views.messageInput.isEnabled = false
+                views.messageInput.setText("")
+                views.messageInput.hint = resources.getString(R.string.write_message_cannot_receive_messages, conversationName)
+                views.actionSend.isEnabled = false
+            }
+        }
     }
 
     private suspend fun updateConversation(pg: PagingData<Api.ConversationMessage>) {

--- a/app/src/main/java/com/pr0gramm/app/ui/fragments/conversation/ConversationViewModel.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/fragments/conversation/ConversationViewModel.kt
@@ -1,7 +1,6 @@
 package com.pr0gramm.app.ui.fragments.conversation
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import androidx.paging.*
 import com.pr0gramm.app.Instant
 import com.pr0gramm.app.R
@@ -22,6 +21,11 @@ class ConversationViewModel(private val inboxService: InboxService, private val 
             firstPageConversationMessages = null
             currentPagingSource = it
         }
+    }
+
+    val partner: LiveData<Api.ConversationMessages.ConversationMessagePartner> = liveData {
+        val partner = inboxService.messagesInConversation(recipient)
+        emit(partner.with)
     }
 
     val paging by lazy { pager.flow.cachedIn(viewModelScope) }

--- a/app/src/main/java/com/pr0gramm/app/ui/views/UserInfoView.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/views/UserInfoView.kt
@@ -74,7 +74,7 @@ class UserInfoView(context: Context) : FrameLayout(context) {
 
         showCommentsContainer.isVisible = comments.isNotEmpty()
 
-        writeNewMessage.isVisible = !myself
+        writeNewMessage.isVisible = !myself && user.canReceiveMessages
 
         // open message dialog for user
         writeNewMessage.setOnClickListener {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -179,6 +179,7 @@
     <string name="write_message_placeholder">Nachricht</string>
     <string name="write_message_send">ABSCHICKEN</string>
     <string name="write_message_title">An %s</string>
+    <string name="write_message_cannot_receive_messages">%s kann keine Nachrichten empfangen.</string>
     <string name="message_must_not_be_empty">Nachricht darf nicht leer sein</string>
     <string name="pref_confirm_play_on_mobile_human__all">Alles bestätigen</string>
     <string name="pref_confirm_play_on_mobile_human__play_direct">Direkt abspielen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,7 @@
     <string name="write_message_placeholder">Message</string>
     <string name="write_message_title">To %s</string>
     <string name="write_message_send">SEND</string>
+    <string name="write_message_cannot_receive_messages">%s cannot receive messages</string>
     <string name="message_must_not_be_empty">The message must not be empty.</string>
     <string name="action_preload">Preload</string>
     <string name="pref_pseudo_clean_preloaded_title">Cleanup preloaded</string>

--- a/model/src/main/java/com/pr0gramm/app/api/pr0gramm/Api.kt
+++ b/model/src/main/java/com/pr0gramm/app/api/pr0gramm/Api.kt
@@ -559,7 +559,8 @@ interface Api {
             val bannedUntil: Instant?,
             val inactive: Boolean = false,
             @Json(name = "commentDelete") val commentDeleteCount: Int,
-            @Json(name = "itemDelete") val itemDeleteCount: Int
+            @Json(name = "itemDelete") val itemDeleteCount: Int,
+            val canReceiveMessages: Boolean = true
         )
 
         @JsonClass(generateAdapter = true)
@@ -808,15 +809,25 @@ interface Api {
         val lastMessage: Instant,
         val mark: Int,
         val name: String,
-        val unreadCount: Int
+        val unreadCount: Int,
+        val canReceiveMessages: Boolean = true
     )
 
     @JsonClass(generateAdapter = true)
     class ConversationMessages(
         val atEnd: Boolean = true,
         val error: String? = null,
-        val messages: List<ConversationMessage> = listOf()
-    )
+        val messages: List<ConversationMessage> = listOf(),
+        val with: ConversationMessagePartner
+    ) {
+        @JsonClass(generateAdapter = true)
+        class ConversationMessagePartner(
+            val name: String,
+            val blocked: Boolean = false,
+            val canReceiveMessages: Boolean = true,
+            val mark: Int
+        )
+    }
 
     @JsonClass(generateAdapter = true)
     class ConversationMessage(


### PR DESCRIPTION
Resolves #256 

Meine Kenntnisse vom Android SDK sind nicht wirklich gut, ich hoffe die Implementierung passt so.

Habe den kurzen Text sowohl für Bots als auch User gewählt, die keine Nachrichten empfangen können. 
Damit wird weniger Platz benötigt und hat mEn. den gleichen Informationsgehalt.

![image](https://user-images.githubusercontent.com/22715034/178279867-cef200a1-16ab-4e05-9d6d-c6cdb4710589.png)
