### PR TITLE
Fix Message sending: nullability of `with` property

### DIFF
--- a/app/src/main/java/com/pr0gramm/app/ui/fragments/conversation/ConversationViewModel.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/fragments/conversation/ConversationViewModel.kt
@@ -77,7 +77,11 @@ class ConversationSource(
                 return LoadResult.Error(StringException("load", R.string.conversation_load_error))
             }
 
-            partner.send(response.with)
+            // It should never be the case that 'response.with' is null as we are only fetching
+            // messages
+            response.with?.let {
+                partner.send(it)
+            }
 
             pending = null
 

--- a/model/src/main/java/com/pr0gramm/app/api/pr0gramm/Api.kt
+++ b/model/src/main/java/com/pr0gramm/app/api/pr0gramm/Api.kt
@@ -818,7 +818,8 @@ interface Api {
         val atEnd: Boolean = true,
         val error: String? = null,
         val messages: List<ConversationMessage> = listOf(),
-        val with: ConversationMessagePartner
+        // Only available in GET /api/inbox/messages
+        val with: ConversationMessagePartner?
     ) {
         @JsonClass(generateAdapter = true)
         class ConversationMessagePartner(


### PR DESCRIPTION
resolves #258 

Getestet für senden und lesen von Nachrichten sowie anzeigen von usern, die keine Nachrichten erhalten können.

Einfache Lösung indem `with` nullable ist. Man könnte auch unterschiedliche Rückgabetypen für die einzelnen Endpunkte festlegen, sodass `POST /api/inbox/post` eine verkürzte Fassung ohne `with` field erhält. 
Das gibt aber Komplikationen in dem ConversationViewModel, wo ich mich nicht rangetraut habe.