### PR TITLE
Add site settings that were added later

### DIFF
--- a/model/src/main/java/com/pr0gramm/app/model/sitesettings/SiteSettingsModel.kt
+++ b/model/src/main/java/com/pr0gramm/app/model/sitesettings/SiteSettingsModel.kt
@@ -11,4 +11,8 @@ data class SiteSettings(
 
     @Json(name = "legacyPath")
     val secondaryServers: Boolean,
+
+    // Unused in the app, but present
+    val showVideoPreview: Boolean,
+    val enableVoteToggle: Boolean,
 )


### PR DESCRIPTION
Ist mir einfach aufgefallen. Weiß nicht, wie das aktuelle Verhalten ist, wenn die beiden Felder nicht vorhanden sind; also z.B. ob die Einstellungen dann immer zurückgesetzt werden oder so. Habs deshalb mal hinzugefügt.

Falls es nicht passt oder so, einfach PR schließen.