### PR TITLE
Remove unused field in DTO

### DIFF
--- a/model/src/main/java/com/pr0gramm/app/api/pr0gramm/Api.kt
+++ b/model/src/main/java/com/pr0gramm/app/api/pr0gramm/Api.kt
@@ -942,7 +942,6 @@ interface Api {
         val success: Boolean,
         /** New version of seen bits. */
         val version: Int,
-        val data: ByteArray,
     )
 
     enum class BanMode {


### PR DESCRIPTION
Possible regression that leads to crash, introduced in #268