### PR TITLE
fix filesize integer overflow

### DIFF
--- a/app/src/main/java/com/pr0gramm/app/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/SettingsFragment.kt
@@ -98,9 +98,9 @@ class SettingsFragment : BasePreferenceFragment("SettingsFragment"),
 
                 val totalSize = runInterruptible(Dispatchers.IO) {
                     items.values().sumOf { item ->
-                        item.media.length().toInt() +
-                                item.thumbnail.length().toInt() +
-                                (item.thumbnailFull?.length()?.toInt() ?: 0)
+                        item.media.length() +
+                                item.thumbnail.length() +
+                                (item.thumbnailFull?.length() ?: 0)
 
                     }
                 }


### PR DESCRIPTION
Die Darstellung der Preloaded Filesize (unter Einstellungen -> Miscellaneous) läuft bei 2GB über und zeigt dann einen negativen Wert an. Wenn man bei der Berechnung einfach den Cast zu Int weglässt würde die Filesize in Long berechnet werden. Damit könnten dann so ca. eine Größe von 9223372036854775mb (9,2 Exabyte) dargestellt werden. Sollte vorerst reichen.