### PR TITLE
Issue 330 - Bereits gesehen Filter

### DIFF
--- a/app/src/main/java/com/pr0gramm/app/Settings.kt
+++ b/app/src/main/java/com/pr0gramm/app/Settings.kt
@@ -84,6 +84,10 @@ object Settings : SharedPreferences.OnSharedPreferenceChangeListener {
         get() = preferences.getBoolean("pref_mark_items_as_seen", false)
         set(value) = edit { putBoolean("pref_mark_items_as_seen", value) }
 
+    var hideSeenPosts: Boolean
+        get() = preferences.getBoolean("pref_hide_seen_posts", false)
+        set(value) = edit { putBoolean("pref_hide_seen_posts", value) }
+
     val fancyScrollVertical: Boolean
         get() = preferences.getBoolean("pref_fancy_scroll_vertical", true)
 

--- a/app/src/main/java/com/pr0gramm/app/ui/fragments/feed/FeedFragment.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/fragments/feed/FeedFragment.kt
@@ -423,6 +423,11 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
                     val repost = inMemoryCacheService.isRepost(id)
                     val preloaded = id in feedState.preloadedItemIds
 
+                    // skip seen items if hideSeenPosts is enabled
+                    if (Settings.hideSeenPosts && seen) {
+                        continue
+                    }
+
                     // show an ad banner every ~50 lines
                     if (feedState.adsVisible && (itemColumnIndex % (50 * thumbnailColumnCount)) == 0) {
                         entries += FeedAdapter.Entry.Ad(itemColumnIndex.toLong())
@@ -817,6 +822,15 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
             // never bookmark a user
             bookmark.isVisible = false
         }
+
+        menu.findItem(R.id.action_hide_seen_posts)?.let { item ->
+            item.setTitle(
+                if (Settings.hideSeenPosts)
+                    R.string.action_show_seen_posts
+                else
+                    R.string.action_hide_seen_posts
+            )
+        }
     }
 
     private fun switchFeedTypeTarget(filter: FeedFilter): FeedType {
@@ -884,6 +898,11 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
             R.id.action_open_in_admin -> openUserInAdmin()
             R.id.action_scroll_seen -> scrollToNextSeenAsync()
             R.id.action_scroll_unseen -> scrollToNextUnseenAsync()
+            R.id.action_hide_seen_posts -> {
+                Settings.hideSeenPosts = !Settings.hideSeenPosts
+                activity?.invalidateOptionsMenu()
+                updateAdapterState(feedStateModel.feedState.value, userStateModel.userState.value)
+            }
 
             else -> super.onOptionsItemSelected(item)
         }

--- a/app/src/main/java/com/pr0gramm/app/ui/fragments/feed/FeedFragment.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/fragments/feed/FeedFragment.kt
@@ -247,6 +247,7 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
         views.refresh.setOnRefreshListener {
             logger.debug { "onRefresh called for swipe view." }
             views.refresh.isRefreshing = false
+            feedStateModel.applyAccumulatedSeenFilter()
             refreshContent()
         }
 
@@ -408,6 +409,7 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
 
             } else if (!userState.userInfoCommentsOpen) {
                 // check if we need to mark posts as 'seen' (respects filter exclusions)
+                val sessionStartSeen = feedState.sessionStartSeenIds
                 val markAsSeen = feedState.markItemsAsSeen && shouldApplySeenFilter(filter)
 
                 // always show at least one ad banner - e.g. during load
@@ -419,12 +421,13 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
 
                 for (item in feedState.feed) {
                     val id = item.id
-                    val seen = markAsSeen && id in feedState.seen
+                    val seenBeforeSession = markAsSeen && (id in sessionStartSeen)
+                    val seen = markAsSeen && (id in feedState.seen)
                     val repost = inMemoryCacheService.isRepost(id)
                     val preloaded = id in feedState.preloadedItemIds
 
-                    // skip seen items (exclusions like collections, profiles, search are handled in markAsSeen)
-                    if (seen) {
+                    // skip seen items that were seen BEFORE current session (exclusions handled in markAsSeen)
+                    if (seenBeforeSession) {
                         continue
                     }
 
@@ -758,6 +761,9 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
             autoScrollRef = startAtItemId?.let { id -> ScrollRef(CommentRef(id)) }
         }
 
+        // Apply accumulated seen filter before replacing feed
+        feedStateModel.applyAccumulatedSeenFilter()
+
         // this clears the current feed immediately
         val filter = feedFilter ?: feed.filter
         feedStateModel.restart(
@@ -980,6 +986,7 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
     private fun switchFeedType() {
         var filter = currentFilter
         filter = filter.withFeedType(switchFeedTypeTarget(filter))
+        feedStateModel.applyAccumulatedSeenFilter()
         (activity as MainActionHandler).onFeedFilterSelected(filter, initialSearchViewState())
     }
 
@@ -1437,6 +1444,7 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
             if (dy < 0 && !feed.isAtStart) {
                 if (firstVisibleItem >= 0 && feed.size > maxEdgeDistance && firstVisibleItem < maxEdgeDistance) {
                     logger.info { "Request previous page now (first visible is $firstVisibleItem of $totalItemCount. Most recent feed item is ${feed.newestNonPlaceholderItem}" }
+                    feedStateModel.applyAccumulatedSeenFilter()
                     feedStateModel.triggerLoadPrev()
                 }
             }

--- a/app/src/main/java/com/pr0gramm/app/ui/fragments/feed/FeedFragment.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/fragments/feed/FeedFragment.kt
@@ -696,8 +696,10 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
         logger.info { "Want to resume from $item" }
 
         val feedToPass = if (shouldApplySeenFilter(feed.filter)) {
+            // Use session-based filtering: only filter posts seen BEFORE this session
+            val sessionStartSeen = feedStateModel.feedState.value.sessionStartSeenIds
             val filteredItems = feed.filter { feedItem ->
-                !seenService.isSeen(feedItem.id)
+                feedItem.id !in sessionStartSeen
             }
             feed.copy(items = filteredItems)
         } else {
@@ -1096,8 +1098,10 @@ class FeedFragment : BaseFragment("FeedFragment", R.layout.fragment_feed), Filte
         autoScrollRef = null
 
         val feedToPass = if (shouldApplySeenFilter(feed.filter)) {
+            // Use session-based filtering: only filter posts seen BEFORE this session
+            val sessionStartSeen = feedStateModel.feedState.value.sessionStartSeenIds
             val filteredItems = feed.filter { feedItem ->
-                !seenService.isSeen(feedItem.id)
+                feedItem.id !in sessionStartSeen
             }
             feed.copy(items = filteredItems)
         } else {

--- a/app/src/main/java/com/pr0gramm/app/ui/fragments/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/fragments/feed/FeedViewModel.kt
@@ -114,6 +114,7 @@ class FeedViewModel(
             feedState.update { previousState ->
                 val seen = previousState.feed.map { it.id }
                     .filterTo(HashSet()) { id -> seenService.isSeen(id) }
+
                 previousState.copy(seen = seen)
             }
         }
@@ -176,10 +177,17 @@ class FeedViewModel(
                             else -> update.feed
                         }
 
+                        val seen = feed.filter { item -> seenService.isSeen(item.id) }
+                            .mapTo(HashSet()) { it.id }
+
+                        // Capture session snapshot: when new feed loads, save current seen state
+                        // This ensures posts seen BEFORE this feed load will be filtered
+                        val sessionStartSeenIds = seen.toSet()
+
                         previousState.copy(
                             feed = feed,
-                            seen = feed.filter { item -> seenService.isSeen(item.id) }
-                                .mapTo(HashSet()) { it.id },
+                            seen = seen,
+                            sessionStartSeenIds = sessionStartSeenIds,
                             empty = update.remote && feed.isEmpty(),
                             highlightedItemIds = highlightedItemIds,
                             autoScrollRef = autoScrollRef,
@@ -494,6 +502,7 @@ class FeedViewModel(
         val ready: Boolean,
         val feed: Feed,
         val seen: Set<Long> = setOf(),
+        val sessionStartSeenIds: Set<Long> = setOf(),
         val errorStr: String? = null,
         val error: Throwable? = null,
         val errorConsumable: ConsumableValue<Throwable>? = null,
@@ -511,6 +520,14 @@ class FeedViewModel(
         val empty: Boolean = false
     ) {
         val isLoading = loading != null
+    }
+
+    fun applyAccumulatedSeenFilter() {
+        feedState.update { previousState ->
+            previousState.copy(
+                sessionStartSeenIds = previousState.seen.toSet()
+            )
+        }
     }
 }
 

--- a/app/src/main/res/menu/menu_feed.xml
+++ b/app/src/main/res/menu/menu_feed.xml
@@ -76,6 +76,11 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_hide_seen_posts"
+        android:title="@string/action_hide_seen_posts"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_block_user"
         android:title="@string/action_block_user"
         android:visible="false"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -576,6 +576,8 @@
     <string name="action_shrink">Verkleinern</string>
     <string name="action_scroll_unseen">Nächster ungesehener Hochlad</string>
     <string name="action_scroll_seen">Nächster gesehener Hochlad</string>
+    <string name="action_hide_seen_posts">Gesehener Hochlad ausblenden</string>
+    <string name="action_show_seen_posts">Gesehener Hochlad einblenden</string>
     <string name="error_max_scroll_reached">Maximale Scrollweite erreicht. Probiere es einfach nochmal.</string>
     <string name="changelog">Changelog</string>
     <string name="user_is_not_verified">Dein Altersnachweis ist noch nicht abgeschlossen. Um nicht jugendfreie Inhalte anzusehen, musst Du dein Alter bestätigen.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -601,6 +601,8 @@
     <string name="action_shrink">Shrink</string>
     <string name="action_scroll_unseen">Scroll next unseen</string>
     <string name="action_scroll_seen">Scroll next seen</string>
+    <string name="action_hide_seen_posts">Hide seen posts</string>
+    <string name="action_show_seen_posts">Show seen posts</string>
     <string name="error_max_scroll_reached">Max scroll distance reached. Please try again.</string>
     <string name="changelog">Changelog</string>
     <string name="user_is_not_verified">Your age was not verified. To be able to access adult content, you need to verify your age.</string>


### PR DESCRIPTION
Stellt neben "nächster gesehener Hochlad" ein weitere Option zur Verfügung mit "Gesehener Hochlad einblenden/ausblenden". Dieser Blendet bereits gesehene Hochlads aus und wieder ein.

Greift nur wenn in "Einstellung -> Visuell -> Bilder als gesehen markieren" aktiviert ist.

![issue-330](https://github.com/user-attachments/assets/dad550e4-2750-44e8-b093-0197deeec2f8)

![issue-330_2](https://github.com/user-attachments/assets/99837005-f4c0-4ca6-8071-6c18addcc24d)
