### PR TITLE
Issue 332 - Probleme mit dem Scrollen bei Markierung

### DIFF
--- a/app/src/main/java/com/pr0gramm/app/ui/StatefulRecyclerView.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/StatefulRecyclerView.kt
@@ -1,12 +1,15 @@
 package com.pr0gramm.app.ui
 
 import android.content.Context
+import android.graphics.Rect
 import android.os.Bundle
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
+import android.view.View
 import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.RecyclerView
+import com.pr0gramm.app.ui.views.CompatibleTextView
 import com.pr0gramm.app.ui.views.TagsView
 import com.pr0gramm.app.util.observeChangeEx
 
@@ -107,6 +110,48 @@ class StatefulRecyclerView @JvmOverloads constructor(
             }
 
             savedHierarchyState = null
+        }
+
+        override fun requestChildRectangleOnScreen(
+            parent: RecyclerView,
+            child: View,
+            rect: Rect,
+            immediate: Boolean
+        ): Boolean {
+            // Prevent automatic scrolling when CompatibleTextView requests to show selection.
+            // This fixes the scroll-to-beginning bug when tapping long comment text.
+            if (child is CompatibleTextView || isCompatibleTextViewInHierarchy(child)) {
+                return false
+            }
+            return super.requestChildRectangleOnScreen(parent, child, rect, immediate)
+        }
+
+        override fun requestChildRectangleOnScreen(
+            parent: RecyclerView,
+            child: View,
+            rect: Rect,
+            immediate: Boolean,
+            focusedChildVisible: Boolean
+        ): Boolean {
+            // Prevent automatic scrolling when CompatibleTextView requests to show selection.
+            // This fixes the scroll-to-beginning bug when tapping long comment text.
+            if (child is CompatibleTextView || isCompatibleTextViewInHierarchy(child)) {
+                return false
+            }
+            return super.requestChildRectangleOnScreen(parent, child, rect, immediate, focusedChildVisible)
+        }
+
+        private fun isCompatibleTextViewInHierarchy(view: View): Boolean {
+            // Check if view contains a CompatibleTextView in its hierarchy
+            if (view is CompatibleTextView) return true
+            if (view is android.view.ViewGroup) {
+                for (i in 0 until view.childCount) {
+                    if (isCompatibleTextViewInHierarchy(view.getChildAt(i))) {
+                        return true
+                    }
+                }
+            }
+            return false
         }
     }
 

--- a/app/src/main/java/com/pr0gramm/app/ui/views/CompatibleTextView.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/views/CompatibleTextView.kt
@@ -1,6 +1,7 @@
 package com.pr0gramm.app.ui.views
 
 import android.content.Context
+import android.graphics.Rect
 import android.os.Build
 import android.text.PrecomputedText
 import android.text.SpannedString
@@ -48,6 +49,14 @@ class CompatibleTextView @JvmOverloads constructor(
         post {
             dispatchTouchEvent(eventCopy)
             eventCopy.recycle()
+        }
+    }
+
+    override fun requestRectangleOnScreen(rectangle: Rect?): Boolean {
+        return if (hasSelection()) {
+            false
+        } else {
+            super.requestRectangleOnScreen(rectangle)
         }
     }
 }

--- a/app/src/main/java/com/pr0gramm/app/ui/views/CompatibleTextView.kt
+++ b/app/src/main/java/com/pr0gramm/app/ui/views/CompatibleTextView.kt
@@ -1,7 +1,6 @@
 package com.pr0gramm.app.ui.views
 
 import android.content.Context
-import android.graphics.Rect
 import android.os.Build
 import android.text.PrecomputedText
 import android.text.SpannedString
@@ -49,14 +48,6 @@ class CompatibleTextView @JvmOverloads constructor(
         post {
             dispatchTouchEvent(eventCopy)
             eventCopy.recycle()
-        }
-    }
-
-    override fun requestRectangleOnScreen(rectangle: Rect?): Boolean {
-        return if (hasSelection()) {
-            false
-        } else {
-            super.requestRectangleOnScreen(rectangle)
         }
     }
 }


### PR DESCRIPTION
Vorab besteht der Verdacht, dass es an den genannten „requestRectangleOnScreen” liegt. Im Allgemeinen wird es ein Zusammenspiel aus verschiedenen Ereignissen sein, z. B. das automatische Scroll-To-Selection-Verhalten von Android oder die Neupositionierung der Blussi-Buttons.

Ich habe mich für eine Variante entschieden, die vorerst minimal invasiv ist und für den Nutzer nicht sichtbar. Das normale Feature bleibt bestehen, d. h., der Text ist weiterhin selektierbar, nur das Auto-Scrollen wird unterdrückt (bei selektierten Text).